### PR TITLE
remove device name from prefix of entity name

### DIFF
--- a/teslamate_mqtt_device_creation_script.yaml
+++ b/teslamate_mqtt_device_creation_script.yaml
@@ -1,5 +1,5 @@
 ## Teslamate Entity Autodiscovery Scripts
-# v1.0.4 - Fix for device_tracker state not updating
+# v1.1.0 - Device naming update for HA 2023.8
 #
 # Instructions: 
 #   1. Edit variables on lines 20-24 per your own setup.
@@ -55,7 +55,7 @@ script:
               retain: true
               payload: >
                 {
-                  "name": "{{ device_name }} {{ model_sensor_friendly_name }}",
+                  "name": "{{ model_sensor_friendly_name }}",
                   "unique_id": "{{ base_topic }}/model",
                   "state_topic": "{{ base_topic }}/model"
                 }
@@ -71,7 +71,7 @@ script:
               retain: true
               payload: >
                 {
-                  "name": "{{ device_name }} {{ sw_version_sensor_friendly_name }}",
+                  "name": "{{ sw_version_sensor_friendly_name }}",
                   "unique_id": "{{ base_topic }}/version",
                   "state_topic": "{{ base_topic }}/version"
                 }
@@ -87,7 +87,7 @@ script:
               retain: true
               payload: >
                 {
-                  "name": "{{ device_name }} {{ trim_badge_sensor_friendly_name }}",
+                  "name": "{{ trim_badge_sensor_friendly_name }}",
                   "unique_id": "{{ base_topic }}/trim_badging",
                   "state_topic": "{{ base_topic }}/trim_badging"
                 }
@@ -847,7 +847,7 @@ script:
                   retain: true
                   payload: >-
                     {
-                      "name": "{{ device_name }} {{ sensor_name }}",
+                      "name": "{{ sensor_name }}",
                       "unique_id": "{{ base_topic | replace("/","_") }}_{{ sensor_name | replace("/","_") | replace(" ","_") | lower }}/{{ object_id }}",
                       {% if availability_value_template is defined and availability_value_template|length %}
                         "availability": [{ "topic": "{{ base_topic }}/{{ availability_topic_suffix }}", "value_template": "{{ '{{' }} {{ availability_value_template }} {{ '}}' }}" }],
@@ -885,4 +885,3 @@ script:
                       {% endif %}
                       "device": {{ device }}
                     }
-


### PR DESCRIPTION
Aligning to changes made to HA 2023.8
https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/