### PR TITLE
Expose navigation values and sample blueprints/automations for route change notifications.

### DIFF
--- a/teslamate_mqtt_device_creation_script.yaml
+++ b/teslamate_mqtt_device_creation_script.yaml
@@ -377,6 +377,28 @@ script:
                       state_class: measurement
                       device_class: pressure
                       unit_of_measurement: bar
+                  - type: sensor
+                    config:
+                      name: Destination
+                      state_topic: "{{ base_topic ~ '/active_route' }}"
+                      value_template: '{{ "{{" }} value_json.destination {{ "}}" }}'
+                      icon: mdi:map-marker-path
+                  - type: sensor
+                    config:
+                      name: Minutes to Arrival
+                      state_topic: "{{ base_topic ~ '/active_route' }}"
+                      value_template: '{{ "{{" }} value_json.minutes_to_arrival | round(1) if value_json.minutes_to_arrival is defined else 0 {{ "}}" }}'
+                      unit_of_measurement: "min"
+                      device_class: duration
+                      icon: mdi:timer-outline
+                  - type: sensor
+                    config:
+                      name: Energy at Arrival
+                      state_topic: "{{ base_topic ~ '/active_route' }}"
+                      value_template: '{{ "{{" }} value_json.energy_at_arrival if value_json.energy_at_arrival is defined else 0 {{ "}}" }}'
+                      unit_of_measurement: "%"
+                      device_class: battery
+                      icon: mdi:battery-check
                   ## Start of Device Trackers ##
                   - type: device_tracker
                     config:

--- a/teslamate_mqtt_device_creation_script.yaml
+++ b/teslamate_mqtt_device_creation_script.yaml
@@ -1,5 +1,5 @@
 ## Teslamate Entity Autodiscovery Script
-# v2.0.1 - Added update_version, charger_phases, usable_battery_level, est_battery_range_km, ideal_battery_range_km
+# v2.1.0 - Added Destination, Minutes to Arrival, and Energy at Arrival sensors
 # 
 # Instructions: 
 #  1. Edit line 21 with your discovery prefix
@@ -381,13 +381,13 @@ script:
                     config:
                       name: Destination
                       state_topic: "{{ base_topic ~ '/active_route' }}"
-                      value_template: '{{ "{{" }} value_json.destination {{ "}}" }}'
+                      value_template: "{{ '{{' }} value_json.destination {{ '}}' }}"
                       icon: mdi:map-marker-path
                   - type: sensor
                     config:
                       name: Minutes to Arrival
                       state_topic: "{{ base_topic ~ '/active_route' }}"
-                      value_template: '{{ "{{" }} value_json.minutes_to_arrival | round(1) if value_json.minutes_to_arrival is defined else 0 {{ "}}" }}'
+                      value_template: "{{ '{{' }} value_json.minutes_to_arrival | round(1) if value_json.minutes_to_arrival is defined else 0 {{ '}}' }}"
                       unit_of_measurement: "min"
                       device_class: duration
                       icon: mdi:timer-outline
@@ -395,7 +395,7 @@ script:
                     config:
                       name: Energy at Arrival
                       state_topic: "{{ base_topic ~ '/active_route' }}"
-                      value_template: '{{ "{{" }} value_json.energy_at_arrival if value_json.energy_at_arrival is defined else 0 {{ "}}" }}'
+                      value_template: "{{ '{{' }} value_json.energy_at_arrival if value_json.energy_at_arrival is defined else 0 {{ '}}' }}"
                       unit_of_measurement: "%"
                       device_class: battery
                       icon: mdi:battery-check


### PR DESCRIPTION
Changes add TeslaMate active route sensors and route change notification automations to the Home Assistant MQTT autodiscovery script.

The core script gains three new MQTT sensors sourced from TeslaMate's active_route topic: Destination (text), Minutes to Arrival (duration, rounded to one decimal), and Energy at Arrival (battery %, with null guards on both computed fields). These give HA first-class entities for navigation state without manual configuration.

On top of those entities, two automation files are added: a reusable blueprint (teslamate-routing-notification-blueprint.yaml) that exposes the destination sensor, notify target, and debounce time as user inputs, and a standalone sample automation (teslamate-routing-automation-sample.yaml) for cases where the blueprint's fixed structure isn't flexible enough. Both share the same logic: debounce on destination change → wait for Drive gear → wait for ETA → stale-route guard → send notification with destination and ETA.

<img width="1008" height="339" alt="Screenshot_20260310-114638" src="https://github.com/user-attachments/assets/96992423-b580-4ad7-a504-4ca18e99c140" />

Please let me know if you have any feedback on these changes or if you would like me to narrow the pull.